### PR TITLE
Change version

### DIFF
--- a/pyangbind/__init__.py
+++ b/pyangbind/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.5.11'
+__version__ = '0.5.11-napalm'


### PR DESCRIPTION
Update the version to avoid confusions.
If often found myself in a new deployment and wasn't sure if I'm
running the official version or this fork.
Note that doing `pip install napalm-yang` didn't install
this fork, but the official and I'm not sure why.
Anyway, till the necessary changes will be released by Rob,
we'd need a way to distinguish between the two code bases.